### PR TITLE
Add support for DHCP; Add missing attributes to AWSIpv6CidrBlock

### DIFF
--- a/cartography/data/indexes.cypher
+++ b/cartography/data/indexes.cypher
@@ -26,6 +26,7 @@ CREATE INDEX ON :Dependency(id);
 CREATE INDEX ON :DBGroup(name);
 CREATE INDEX ON :DNSRecord(id);
 CREATE INDEX ON :DNSZone(name);
+CREATE INDEX ON :DHCPOptions(id);
 CREATE INDEX ON :DynamoDBGlobalSecondaryIndex(id);
 CREATE INDEX ON :DynamoDBTable(arn);
 CREATE INDEX ON :DynamoDBTable(id);

--- a/cartography/data/jobs/cleanup/aws_import_dhcp_options_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_dhcp_options_cleanup.json
@@ -6,4 +6,3 @@
   }],
   "name": "cleanup Dhcp Options"
 }
-  

--- a/cartography/data/jobs/cleanup/aws_import_dhcp_options_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_dhcp_options_cleanup.json
@@ -1,0 +1,9 @@
+{
+  "statements": [{
+    "query": "MATCH (n:DHCPOptions)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "iterative": true,
+    "iterationsize": 100
+  }],
+  "name": "cleanup Dhcp Options"
+}
+  

--- a/cartography/data/jobs/cleanup/aws_import_vpc_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_vpc_cleanup.json
@@ -18,6 +18,11 @@
     "query": "MATCH (:AWSVpc)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
     "iterative": true,
     "iterationsize": 100
+  },
+  {
+    "query": "MATCH (:DHCPOptions)<-[r:DHCP_ASSOCIATION]-(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "iterative": true,
+      "iterationsize": 100
   }],
   "name": "cleanup AWS VPC information"
 }

--- a/cartography/intel/aws/ec2/__init__.py
+++ b/cartography/intel/aws/ec2/__init__.py
@@ -1,6 +1,7 @@
 import logging
 
 from .auto_scaling_groups import sync_ec2_auto_scaling_groups
+from .dhcp_options import sync_dhcp_options
 from .instances import sync_ec2_instances
 from .key_pairs import sync_ec2_key_pairs
 from .load_balancer_v2s import sync_load_balancer_v2s
@@ -27,6 +28,7 @@ def get_ec2_regions(boto3_session):
 @timeit
 def sync(neo4j_session, boto3_session, regions, account_id, sync_tag, common_job_parameters):
     logger.info("Syncing EC2 for account '%s'.", account_id)
+    sync_dhcp_options(neo4j_session, boto3_session, regions, account_id, sync_tag, common_job_parameters)
     sync_vpc(neo4j_session, boto3_session, regions, account_id, sync_tag, common_job_parameters)
     sync_ec2_security_groupinfo(neo4j_session, boto3_session, regions, account_id, sync_tag, common_job_parameters)
     sync_ec2_key_pairs(neo4j_session, boto3_session, regions, account_id, sync_tag, common_job_parameters)

--- a/cartography/intel/aws/ec2/dhcp_options.py
+++ b/cartography/intel/aws/ec2/dhcp_options.py
@@ -1,0 +1,60 @@
+import logging
+import json
+
+from .util import get_botocore_config
+from cartography.util import aws_handle_regions
+from cartography.util import run_cleanup_job
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+@timeit
+@aws_handle_regions
+def get_dhcp_options_data(boto3_session, region):
+    client = boto3_session.client('ec2', region_name=region, config=get_botocore_config())
+    paginator = client.get_paginator('describe_dhcp_options')
+    dhcp_options = []
+    for page in paginator.paginate():
+        dhcp_options.extend(page['DhcpOptions'])
+    return dhcp_options
+
+
+def load_dhcp_options(neo4j_session, data, region, aws_account_id, aws_update_tag):
+
+    for dhcp_options in data:
+        import_dhcp_options = ("""
+        MERGE (dhcp:DHCPOptions{id: {DhcpOptionsId}})
+        ON CREATE SET dhcp.firstseen = timestamp()
+        SET dhcp.lastupdated = {aws_update_tag},
+        dhcp.dhcpoptionsid = {DhcpOptionsId},
+        dhcp.region = {region},
+        dhcp.dhcp_configurations = '%s'
+        WITH dhcp
+        MATCH (awsAccount:AWSAccount{id: {aws_account_id}})
+        MERGE (awsAccount)-[r:RESOURCE]->(dhcp)
+        ON CREATE SET r.firstseen = timestamp()
+        SET r.lastupdated = {aws_update_tag}
+        """ % json.dumps(dhcp_options['DhcpConfigurations']))
+    
+        neo4j_session.run(
+            import_dhcp_options, DhcpOptionsId=dhcp_options['DhcpOptionsId'], aws_update_tag=aws_update_tag,
+            region=region, aws_account_id=aws_account_id,
+        )
+
+
+@timeit
+def cleanup_dhcp_options(neo4j_session, common_job_parameters):
+    run_cleanup_job('aws_import_dhcp_options_cleanup.json', neo4j_session, common_job_parameters)
+
+
+@timeit
+def sync_dhcp_options(
+    neo4j_session, boto3_session, regions, current_aws_account_id, aws_update_tag,
+    common_job_parameters,
+):
+    for region in regions:
+        logger.debug("Syncing EC2 internet gateways for region '%s' in account '%s'.", region, current_aws_account_id)
+        data = get_dhcp_options_data(boto3_session, region)
+        load_dhcp_options(neo4j_session, data, region, current_aws_account_id, aws_update_tag)
+    cleanup_dhcp_options(neo4j_session, common_job_parameters)

--- a/cartography/intel/aws/ec2/vpc.py
+++ b/cartography/intel/aws/ec2/vpc.py
@@ -27,6 +27,8 @@ def _get_cidr_association_statement(block_type):
         new_block.cidr_block = block_data.$block_cidr,
         new_block.block_state = block_data.$state_name.State,
         new_block.block_state_message = block_data.$state_name.StatusMessage,
+        new_block.ipv6_pool = block_data.Ipv6Pool,
+        new_block.network_border_group = block_data.NetworkBorderGroup,
         new_block.lastupdated = {aws_update_tag}
         WITH vpc, new_block
         MERGE (vpc)-[r:BLOCK_ASSOCIATION]->(new_block)

--- a/cartography/intel/aws/ec2/vpc.py
+++ b/cartography/intel/aws/ec2/vpc.py
@@ -113,6 +113,11 @@ def load_ec2_vpcs(neo4j_session, data, region, current_aws_account_id, aws_updat
     MATCH (awsAccount:AWSAccount{id: {AWS_ACCOUNT_ID}})
     MERGE (awsAccount)-[r:RESOURCE]->(new_vpc)
     ON CREATE SET r.firstseen = timestamp()
+    SET r.lastupdated = {aws_update_tag}
+    WITH new_vpc
+    MATCH (dhcpOptions:DHCPOptions{id: {DhcpOptionsId}})
+    MERGE (dhcpOptions)<-[r:DHCP_ASSOCIATION]-(new_vpc)
+    ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = {aws_update_tag}"""
 
     for vpc in data:

--- a/cartography/intel/aws/resourcegroupstaggingapi.py
+++ b/cartography/intel/aws/resourcegroupstaggingapi.py
@@ -45,6 +45,7 @@ def get_bucket_name_from_arn(bucket_arn):
 # cartography uses.
 # TODO - we should make EC2 and S3 assets query-able by their full ARN so that we don't need this workaround.
 TAG_RESOURCE_TYPE_MAPPINGS = {
+    'ec2:dhcp-options': {'label': 'DHCPOptions', 'property': 'id', 'id_func': get_short_id_from_ec2_arn},
     'ec2:instance': {'label': 'EC2Instance', 'property': 'id', 'id_func': get_short_id_from_ec2_arn},
     'ec2:network-interface': {'label': 'NetworkInterface', 'property': 'id', 'id_func': get_short_id_from_ec2_arn},
     'ec2:security-group': {'label': 'EC2SecurityGroup', 'property': 'id', 'id_func': get_short_id_from_ec2_arn},


### PR DESCRIPTION
This PR handles two things
- Adds the intel module to support DHCP Options set.
  - Adds the `DHCP_ASSOCIATION` relationship from `VPC` to `DHCPOptions`
- Adds following attributes to the AWSIpv6CidrBlock attached with VPC
  - Ipv6Pool
  - NetworkBorderPool