### PR TITLE
Add support for internet gateway and route table; Add Cidr association nodes in Subnet

### DIFF
--- a/cartography/data/indexes.cypher
+++ b/cartography/data/indexes.cypher
@@ -33,7 +33,7 @@ CREATE INDEX ON :DynamoDBTable(id);
 CREATE INDEX ON :EC2Instance(id);
 CREATE INDEX ON :EC2Instance(instanceid);
 CREATE INDEX ON :EC2Instance(publicdnsname);
-CREATE INDEX ON :EC2InternetGateway(id)
+CREATE INDEX ON :InternetGateway(id)
 CREATE INDEX ON :EC2KeyPair(id);
 CREATE INDEX ON :EC2PrivateIp(id);
 CREATE INDEX ON :EC2Reservation(reservationid);

--- a/cartography/data/indexes.cypher
+++ b/cartography/data/indexes.cypher
@@ -33,6 +33,7 @@ CREATE INDEX ON :DynamoDBTable(id);
 CREATE INDEX ON :EC2Instance(id);
 CREATE INDEX ON :EC2Instance(instanceid);
 CREATE INDEX ON :EC2Instance(publicdnsname);
+CREATE INDEX ON :EC2InternetGateway(id)
 CREATE INDEX ON :EC2KeyPair(id);
 CREATE INDEX ON :EC2PrivateIp(id);
 CREATE INDEX ON :EC2Reservation(reservationid);
@@ -112,6 +113,8 @@ CREATE INDEX ON :RDSInstance(id);
 CREATE INDEX ON :RDSInstance(arn);
 CREATE INDEX ON :ReplyUri(id)
 CREATE INDEX ON :Risk(id);
+CREATE INDEX ON :Route(id)
+CREATE INDEX ON :RouteTable(id)
 CREATE INDEX ON :S3Acl(id);
 CREATE INDEX ON :S3Bucket(id);
 CREATE INDEX ON :S3Bucket(name);

--- a/cartography/data/jobs/cleanup/aws_import_tags_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_tags_cleanup.json
@@ -99,6 +99,46 @@
             "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:S3Bucket) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
+        },
+        {
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:DHCPOptions) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+            "iterative": true,
+            "iterationsize": 100
+        },
+        {
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:DHCPOptions) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+            "iterative": true,
+            "iterationsize": 100
+        },
+        {
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:InternetGateway) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+            "iterative": true,
+            "iterationsize": 100
+        },
+        {
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:InternetGateway) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+            "iterative": true,
+            "iterationsize": 100
+        },
+        {
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:NetworkAcl) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+            "iterative": true,
+            "iterationsize": 100
+        },
+        {
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:NetworkAcl) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+            "iterative": true,
+            "iterationsize": 100
+        },
+        {
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:RouteTable) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+            "iterative": true,
+            "iterationsize": 100
+        },
+        {
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:RouteTable) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+            "iterative": true,
+            "iterationsize": 100
         }
     ],
     "name": "cleanup AWS Tags"

--- a/cartography/data/jobs/cleanup/aws_ingest_internet_gateways_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_ingest_internet_gateways_cleanup.json
@@ -1,0 +1,16 @@
+{
+    "statements": [
+    {
+      "query": "MATCH (n:EC2InternetGateway)-[r:ATTACHED_TO]->(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "iterative": true,
+      "iterationsize": 100
+    },
+    {
+    "query": "MATCH (n:EC2InternetGateway)-[r:ATTACHED_TO]->(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "iterative": true,
+      "iterationsize": 100
+    }
+    ],
+    "name": "cleanup Internet Gateway"
+  }
+  

--- a/cartography/data/jobs/cleanup/aws_ingest_internet_gateways_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_ingest_internet_gateways_cleanup.json
@@ -1,16 +1,13 @@
 {
-    "statements": [
-    {
-      "query": "MATCH (n:EC2InternetGateway)-[r:ATTACHED_TO]->(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
-      "iterative": true,
-      "iterationsize": 100
+    "statements": [{
+        "query": "MATCH (n:EC2InternetGateway)-[r:ATTACHED_TO]->(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+        "iterative": true,
+        "iterationsize": 100
     },
     {
-    "query": "MATCH (n:EC2InternetGateway)-[r:ATTACHED_TO]->(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
-      "iterative": true,
-      "iterationsize": 100
-    }
-    ],
+        "query": "MATCH (n:EC2InternetGateway)-[r:ATTACHED_TO]->(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+        "iterative": true,
+        "iterationsize": 100
+    }],
     "name": "cleanup Internet Gateway"
-  }
-  
+}

--- a/cartography/data/jobs/cleanup/aws_ingest_internet_gateways_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_ingest_internet_gateways_cleanup.json
@@ -1,11 +1,16 @@
 {
     "statements": [{
-        "query": "MATCH (n:EC2InternetGateway)-[r:ATTACHED_TO]->(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+        "query": "MATCH (n:InternetGateway)-[r:ATTACHED_TO]->(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
         "iterative": true,
         "iterationsize": 100
     },
     {
-        "query": "MATCH (n:EC2InternetGateway)-[r:ATTACHED_TO]->(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+        "query": "MATCH (n:InternetGateway)-[r:ATTACHED_TO]->(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+        "iterative": true,
+        "iterationsize": 100
+    },
+    {
+        "query": "MATCH (:InternetGateway)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
         "iterative": true,
         "iterationsize": 100
     }],

--- a/cartography/data/jobs/cleanup/aws_ingest_route_tables_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_ingest_route_tables_cleanup.json
@@ -20,5 +20,4 @@
         "iterationsize": 100
     }],
     "name": "cleanup Route Table"
-  }
-  
+}

--- a/cartography/data/jobs/cleanup/aws_ingest_route_tables_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_ingest_route_tables_cleanup.json
@@ -10,7 +10,7 @@
         "iterationsize": 100
     },
     {
-        "query": "MATCH (:EC2Subnet)-[r:SUBNET_ASSOCIATION]->(:RouteTable)-[:MEMBER_OF_AWS_VPC]->(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+        "query": "MATCH (:EC2Subnet)-[r:SUBNET_ASSOCIATION]->(:RouteTable)-[:MEMBER_OF_AWS_VPC]->(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
         "iterative": true,
         "iterationsize": 100
     },

--- a/cartography/data/jobs/cleanup/aws_ingest_route_tables_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_ingest_route_tables_cleanup.json
@@ -1,0 +1,24 @@
+{
+    "statements": [{
+        "query": "MATCH (n)<-[r:ROUTE_TARGET]-(n:Route)-[:ROUTE_OF]->(:RouteTable)-[:MEMBER_OF_AWS_VPC]->(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+        "iterative": true,
+        "iterationsize": 100
+    },
+    {
+        "query": "MATCH (n:Route)-[:ROUTE_OF]->(:RouteTable)-[r:MEMBER_OF_AWS_VPC]->(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+        "iterative": true,
+        "iterationsize": 100
+    },
+    {
+        "query": "MATCH (:EC2Subnet)-[r:SUBNET_ASSOCIATION]->(:RouteTable)-[:MEMBER_OF_AWS_VPC]->(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+        "iterative": true,
+        "iterationsize": 100
+    },
+    {
+        "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSVpc)<-[r:MEMBER_OF_AWS_VPC]-(n:RouteTable) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+        "iterative": true,
+        "iterationsize": 100
+    }],
+    "name": "cleanup Route Table"
+  }
+  

--- a/cartography/data/jobs/cleanup/aws_ingest_subnets_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_ingest_subnets_cleanup.json
@@ -1,9 +1,18 @@
 {
-  "statements": [{
-    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSVpc)<-[r:MEMBER_OF_AWS_VPC]-(n:EC2Subnet) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
-    "iterative": true,
-    "iterationsize": 100
-  }
-  ],
-  "name": "cleanup Subnet"
+    "statements": [{
+        "query": "MATCH (n:CidrBlock)<-[:BLOCK_ASSOCIATION]-(:EC2Subnet)-[r:MEMBER_OF_AWS_VPC]->(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+        "iterative": true,
+        "iterationsize": 100
+    },
+    {
+        "query": "MATCH (:CidrBlock)<-[r:BLOCK_ASSOCIATION]-(:EC2Subnet)-[rv:MEMBER_OF_AWS_VPC]->(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+        "iterative": true,
+        "iterationsize": 100
+    },
+    {
+        "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSVpc)<-[r:MEMBER_OF_AWS_VPC]-(n:EC2Subnet) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+        "iterative": true,
+        "iterationsize": 100
+    }],
+    "name": "cleanup Subnet"
 }

--- a/cartography/intel/aws/ec2/__init__.py
+++ b/cartography/intel/aws/ec2/__init__.py
@@ -3,6 +3,10 @@ import logging
 from .auto_scaling_groups import sync_ec2_auto_scaling_groups
 from .dhcp_options import sync_dhcp_options
 from .instances import sync_ec2_instances
+from .internet_gateway import sync_internet_gateways
+from .dhcp_options import sync_dhcp_options
+from .network_acl import sync_network_acls
+from .route_table import sync_route_tables
 from .key_pairs import sync_ec2_key_pairs
 from .load_balancer_v2s import sync_load_balancer_v2s
 from .load_balancers import sync_load_balancers
@@ -31,6 +35,7 @@ def sync(neo4j_session, boto3_session, regions, account_id, sync_tag, common_job
     logger.info("Syncing EC2 for account '%s'.", account_id)
     sync_dhcp_options(neo4j_session, boto3_session, regions, account_id, sync_tag, common_job_parameters)
     sync_vpc(neo4j_session, boto3_session, regions, account_id, sync_tag, common_job_parameters)
+    sync_internet_gateways(neo4j_session, boto3_session, regions, account_id, sync_tag, common_job_parameters)
     sync_ec2_security_groupinfo(neo4j_session, boto3_session, regions, account_id, sync_tag, common_job_parameters)
     sync_ec2_key_pairs(neo4j_session, boto3_session, regions, account_id, sync_tag, common_job_parameters)
     sync_ec2_instances(neo4j_session, boto3_session, regions, account_id, sync_tag, common_job_parameters)
@@ -43,3 +48,4 @@ def sync(neo4j_session, boto3_session, regions, account_id, sync_tag, common_job
     sync_vpc_peering(neo4j_session, boto3_session, regions, account_id, sync_tag, common_job_parameters)
     sync_transit_gateways(neo4j_session, boto3_session, regions, account_id, sync_tag, common_job_parameters)
     sync_network_interfaces(neo4j_session, boto3_session, regions, account_id, sync_tag, common_job_parameters)
+    sync_route_tables(neo4j_session, boto3_session, regions, account_id, sync_tag, common_job_parameters)

--- a/cartography/intel/aws/ec2/internet_gateway.py
+++ b/cartography/intel/aws/ec2/internet_gateway.py
@@ -24,11 +24,12 @@ def load_attachments(neo4j_session, internet_gateways, aws_update_tag):
     ingest_internet_gateway_vpc_relations = """
     UNWIND {InternetGateways} as internet_gateway
     UNWIND internet_gateway.Attachments as attachment
-    MATCH (igw:EC2InternetGateway{id: internet_gateway.InternetGatewayId}),
+    MATCH (igw:InternetGateway{id: internet_gateway.InternetGatewayId}),
         (vpc:AWSVpc{id: attachment.VpcId})
     MERGE (igw)-[r:ATTACHED_TO]->(vpc)
     ON CREATE SET r.firstseen = timestamp()
-    SET r.lastupdated = {aws_update_tag}
+    SET r.state = attachment.State,
+    r.lastupdated = {aws_update_tag}
     """
 
     neo4j_session.run(
@@ -42,16 +43,29 @@ def load_internet_gateways(neo4j_session, data, region, aws_account_id, aws_upda
 
     ingest_internet_gateways = """
     UNWIND {internet_gateways} as internet_gateway
-    MERGE (igw:EC2InternetGateway{id: internet_gateway.InternetGatewayId})
+    MERGE (igw:InternetGateway{id: internet_gateway.InternetGatewayId})
     ON CREATE SET igw.firstseen = timestamp()
     SET igw.lastupdated = {aws_update_tag},
     igw.region = {region},
     igw.internetgatewayid = internet_gateway.InternetGatewayId
     """
 
+    ingest_internet_gateway_aws_account_relations = """
+    UNWIND {internet_gateways} as internet_gateway
+    MATCH (igw:InternetGateway{id: internet_gateway.InternetGatewayId}), (aws:AWSAccount{id: {aws_account_id}})
+    MERGE (aws)-[r:RESOURCE]->(igw)
+    ON CREATE SET r.firstseen = timestamp()
+    SET r.lastupdated = {aws_update_tag}
+    """
+
     neo4j_session.run(
         ingest_internet_gateways, internet_gateways=data, aws_update_tag=aws_update_tag,
-        region=region, aws_account_id=aws_account_id,
+        region=region
+    )
+
+    neo4j_session.run(
+        ingest_internet_gateway_aws_account_relations, internet_gateways=data, aws_update_tag=aws_update_tag,
+        aws_account_id=aws_account_id
     )
 
     load_attachments(
@@ -72,7 +86,7 @@ def sync_internet_gateways(
     common_job_parameters,
 ):
     for region in regions:
-        logger.debug("Syncing EC2 internet gateways for region '%s' in account '%s'.", region, current_aws_account_id)
+        logger.info("Syncing EC2 internet gateways for region '%s' in account '%s'.", region, current_aws_account_id)
         data = get_internet_gateway_data(boto3_session, region)
         load_internet_gateways(neo4j_session, data, region, current_aws_account_id, aws_update_tag)
     cleanup_internet_gateways(neo4j_session, common_job_parameters)

--- a/cartography/intel/aws/ec2/internet_gateway.py
+++ b/cartography/intel/aws/ec2/internet_gateway.py
@@ -1,0 +1,78 @@
+import logging
+from string import Template
+
+from .util import get_botocore_config
+from cartography.util import aws_handle_regions
+from cartography.util import run_cleanup_job
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+@timeit
+@aws_handle_regions
+def get_internet_gateway_data(boto3_session, region):
+    client = boto3_session.client('ec2', region_name=region, config=get_botocore_config())
+    paginator = client.get_paginator('describe_internet_gateways')
+    internet_gateways = []
+    for page in paginator.paginate():
+        internet_gateways.extend(page['InternetGateways'])
+    return internet_gateways
+
+@timeit
+def load_attachments(neo4j_session, internet_gateways, aws_update_tag):
+    ingest_internet_gateway_vpc_relations = """
+    UNWIND {InternetGateways} as internet_gateway
+    UNWIND internet_gateway.Attachments as attachment
+    MATCH (igw:EC2InternetGateway{id: internet_gateway.InternetGatewayId}),
+        (vpc:AWSVpc{id: attachment.VpcId})
+    MERGE (igw)-[r:ATTACHED_TO]->(vpc)
+    ON CREATE SET r.firstseen = timestamp()
+    SET r.lastupdated = {aws_update_tag}
+    """
+
+    neo4j_session.run(
+        ingest_internet_gateway_vpc_relations,
+        InternetGateways=internet_gateways,
+        aws_update_tag=aws_update_tag,
+    )
+
+
+def load_internet_gateways(neo4j_session, data, region, aws_account_id, aws_update_tag):
+
+    ingest_internet_gateways = """
+    UNWIND {internet_gateways} as internet_gateway
+    MERGE (igw:EC2InternetGateway{id: internet_gateway.InternetGatewayId})
+    ON CREATE SET igw.firstseen = timestamp()
+    SET igw.lastupdated = {aws_update_tag},
+    igw.region = {region},
+    igw.internetgatewayid = internet_gateway.InternetGatewayId
+    """
+
+    neo4j_session.run(
+        ingest_internet_gateways, internet_gateways=data, aws_update_tag=aws_update_tag,
+        region=region, aws_account_id=aws_account_id,
+    )
+
+    load_attachments(
+        neo4j_session,
+        internet_gateways=data,
+        aws_update_tag=aws_update_tag,
+    )
+
+
+@timeit
+def cleanup_internet_gateways(neo4j_session, common_job_parameters):
+    run_cleanup_job('aws_ingest_internet_gateways_cleanup.json', neo4j_session, common_job_parameters)
+
+
+@timeit
+def sync_internet_gateways(
+    neo4j_session, boto3_session, regions, current_aws_account_id, aws_update_tag,
+    common_job_parameters,
+):
+    for region in regions:
+        logger.debug("Syncing EC2 internet gateways for region '%s' in account '%s'.", region, current_aws_account_id)
+        data = get_internet_gateway_data(boto3_session, region)
+        load_internet_gateways(neo4j_session, data, region, current_aws_account_id, aws_update_tag)
+    cleanup_internet_gateways(neo4j_session, common_job_parameters)

--- a/cartography/intel/aws/ec2/route_table.py
+++ b/cartography/intel/aws/ec2/route_table.py
@@ -1,0 +1,217 @@
+import logging
+
+from .util import get_botocore_config
+from cartography.util import aws_handle_regions
+from cartography.util import run_cleanup_job
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+@timeit
+@aws_handle_regions
+def get_route_table_data(boto3_session, region):
+    client = boto3_session.client('ec2', region_name=region, config=get_botocore_config())
+    paginator = client.get_paginator('describe_route_tables')
+    route_tables = []
+    for page in paginator.paginate():
+        route_tables.extend(page['RouteTables'])
+    return route_tables
+
+
+def _get_implicit_subnet_association_statement():
+    INGEST_IMPLICIT_SUBNET_ASSOCIATIONS_TEMPLATE ="""
+    UNWIND {RouteTables} as route_table
+    UNWIND route_table.Associations as association
+        MATCH (rtable:RouteTable{id: route_table.RouteTableId})
+        MATCH (n:EC2Subnet{vpc_id: route_table.VpcId}) WHERE NOT EXISTS((n)-[:SUBNET_ASSOCIATION]->(:RouteTable))
+        FOREACH(ignoreMe IN CASE association.Main when true THEN [1] ELSE [] END |
+            MERGE(n)-[r:SUBNET_ASSOCIATION]->(rtable)
+            ON CREATE SET r.firstseen = timestamp()
+            SET r.is_implicit = true,
+            r.lastupdated = {aws_update_tag}
+        )
+    """
+    return INGEST_IMPLICIT_SUBNET_ASSOCIATIONS_TEMPLATE
+
+
+def _get_explicit_subnet_association_statement():
+    INGEST_EXPLICIT_SUBNET_ASSOCIATIONS_TEMPLATE ="""
+    UNWIND {RouteTables} as route_table
+    UNWIND route_table.Associations as association
+        MATCH (rtable:RouteTable{id: route_table.RouteTableId})
+        MATCH (snet:EC2Subnet{subnetid: association.SubnetId})
+        FOREACH(ignoreMe IN CASE association.Main when true THEN [] ELSE [1] END |
+            MERGE(snet)-[r:SUBNET_ASSOCIATION]->(rtable)
+            ON CREATE SET r.firstseen = timestamp()
+            SET r.is_implicit = false,
+            r.lastupdated = {aws_update_tag}
+        )
+    """
+    return INGEST_EXPLICIT_SUBNET_ASSOCIATIONS_TEMPLATE
+
+
+@timeit
+def load_subnet_associations(neo4j_session, route_tables, aws_update_tag):
+    explicit_subnet_association_statement = _get_explicit_subnet_association_statement()
+    implicit_subnet_association_statement = _get_implicit_subnet_association_statement()
+
+    neo4j_session.run(explicit_subnet_association_statement,
+        RouteTables=route_tables,
+        aws_update_tag=aws_update_tag,
+    )
+
+    neo4j_session.run(implicit_subnet_association_statement,
+        RouteTables=route_tables,
+        aws_update_tag=aws_update_tag,
+    )
+
+
+def _get_routes_statement():
+    INGEST_ROUTE_TEMPLATE ="""
+    UNWIND {RouteTables} as route_table
+    UNWIND route_table.Routes as route_data
+        MERGE (new_route:Route{id: route_table.RouteTableId + '|' + 
+        Case route_data.DestinationCidrBlock when null then
+        (Case route_data.DestinationIpv6CidrBlock when null then route_data.DestinationPrefixListId else
+        route_data.DestinationIpv6CidrBlock end)
+        else route_data.DestinationCidrBlock end})
+        ON CREATE SET new_route.firstseen = timestamp()
+        SET new_route.destination_cidr_block = route_data.DestinationCidrBlock,
+        new_route.destination_ipv6_cidr_block = route_data.DestinationIpv6CidrBlock,
+        new_route.destination_prefix_list_id = route_data.DestinationPrefixListId,
+        new_route.egress_only_internet_gateway_id = route_data.EgressOnlyInternetGatewayId,
+        new_route.gateway_id = route_data.GatewayId,
+        new_route.instance_id = route_data.InstanceId,
+        new_route.nat_gateway_id = route_data.NatGatewayId,
+        new_route.transit_gateway_id = route_data.TransitGatewayId,
+        new_route.network_interface_id = route_data.NetworkInterfaceId,
+        new_route.vpc_peering_connection_id = route_data.VpcPeeringConnectionId,
+        new_route.lastupdated = {aws_update_tag}
+
+        WITH new_route, route_table
+        MATCH (rtable:RouteTable{id: route_table.RouteTableId})
+        MERGE (new_route)-[r:ROUTE_OF]->(rtable)
+        ON CREATE SET r.firstseen = timestamp()
+        SET r.lastupdated = {aws_update_tag}
+
+        WITH new_route
+        FOREACH(ignoreMe IN CASE new_route.destination_cidr_block when null THEN [] ELSE [1] END |
+            MERGE (new_block:AWSCidrBlock:AWSIpv4CidrBlock{id: new_route.id + '|' + 'cidr'})
+            ON CREATE SET new_block.firstseen = timestamp()
+            SET new_block.cidr_block = new_route.destination_cidr_block,
+            new_block.lastupdated = {aws_update_tag}
+            MERGE (new_route)-[r:BLOCK_ASSOCIATION]->(new_block)
+            ON CREATE SET r.firstseen = timestamp()
+            SET r.lastupdated = {aws_update_tag}
+        )
+
+        WITH new_route
+        FOREACH(ignoreMe IN CASE new_route.destination_ipv6_cidr_block when null THEN [] ELSE [1] END |
+            MERGE (new_block:AWSCidrBlock:AWSIpv6CidrBlock{id: new_route.id + '|' + 'cidr'})
+            ON CREATE SET new_block.firstseen = timestamp()
+            SET new_block.cidr_block = new_route.destination_ipv6_cidr_block,
+            new_block.lastupdated = {aws_update_tag}
+            MERGE (new_route)-[r:BLOCK_ASSOCIATION]->(new_block)
+            ON CREATE SET r.firstseen = timestamp()
+            SET r.lastupdated = {aws_update_tag}
+        )
+
+        WITH new_route
+        OPTIONAL MATCH (tgw:AWSTransitGateway{tgw_id: new_route.transit_gateway_id})
+        WITH tgw, new_route
+        FOREACH(ignoreMe IN CASE tgw WHEN null THEN [] ELSE [1] END |
+            MERGE (new_route)-[r:ROUTE_TARGET]->(tgw)
+            ON CREATE SET r.firstseen = timestamp()
+            SET r.lastupdated = {aws_update_tag}
+        )
+
+        WITH new_route
+        OPTIONAL MATCH (network_interface:NetworkInterface{id: new_route.network_interface_id})
+        WITH network_interface, new_route
+        FOREACH(ignoreMe IN CASE network_interface WHEN null THEN [] ELSE [1] END |
+            MERGE (new_route)-[r:ROUTE_TARGET]->(network_interface)
+            ON CREATE SET r.firstseen = timestamp()
+            SET r.lastupdated = {aws_update_tag}
+        )
+
+        WITH new_route
+        OPTIONAL MATCH (igw:EC2InternetGateway{id: new_route.gateway_id})
+        WITH igw, new_route
+        FOREACH(ignoreMe IN CASE igw WHEN null THEN [] ELSE [1] END |
+            MERGE (new_route)-[r:ROUTE_TARGET]->(igw)
+            ON CREATE SET r.firstseen = timestamp()
+            SET r.lastupdated = {aws_update_tag}
+        )
+        """
+        # ToDo: Add ROUTE_TARGET relation with other types of target of routes.
+    return INGEST_ROUTE_TEMPLATE
+
+
+@timeit
+def load_routes(neo4j_session, route_tables, aws_update_tag):
+    ingest_statement = _get_routes_statement()
+    neo4j_session.run(
+        ingest_statement,
+        RouteTables=route_tables,
+        aws_update_tag=aws_update_tag,
+    )
+
+
+def load_route_tables(neo4j_session, data, region, aws_account_id, aws_update_tag):
+
+    ingest_route_tables = """
+    UNWIND {route_tables} as route_table
+    MERGE (rtable:RouteTable{id: route_table.RouteTableId})
+    ON CREATE SET rtable.firstseen = timestamp()
+    SET rtable.lastupdated = {aws_update_tag},
+    rtable.region = {region},
+    rtable.vpc_id = route_table.VpcId,
+    rtable.route_table_id = route_table.RouteTableId
+    """
+
+    ingest_route_table_vpc_relations = """
+    UNWIND {route_tables} as route_table
+    MATCH (rtable:RouteTable{id: route_table.RouteTableId}), (vpc:AWSVpc{id: route_table.VpcId})
+    MERGE (rtable)-[r:MEMBER_OF_AWS_VPC]->(vpc)
+    ON CREATE SET r.firstseen = timestamp()
+    SET r.lastupdated = {aws_update_tag}
+    """
+
+    ingest_route_table_aws_account_relations = """
+    UNWIND {route_tables} as route_table
+    MATCH (rtable:RouteTable{id: route_table.RouteTableId}), (aws:AWSAccount{id: {aws_account_id}})
+    MERGE (aws)-[r:RESOURCE]->(rtable)
+    ON CREATE SET r.firstseen = timestamp()
+    SET r.lastupdated = {aws_update_tag}
+    """
+
+    neo4j_session.run(ingest_route_tables, route_tables=data, aws_update_tag=aws_update_tag,
+        region=region)
+
+    neo4j_session.run(ingest_route_table_vpc_relations, route_tables=data,
+        aws_update_tag=aws_update_tag)
+
+    neo4j_session.run(ingest_route_table_aws_account_relations, route_tables=data,
+        aws_update_tag=aws_update_tag, aws_account_id=aws_account_id)
+
+    load_routes(neo4j_session, route_tables=data, aws_update_tag=aws_update_tag)
+
+    load_subnet_associations(neo4j_session, route_tables=data, aws_update_tag=aws_update_tag)
+
+
+@timeit
+def cleanup_route_tables(neo4j_session, common_job_parameters):
+    run_cleanup_job('aws_ingest_route_tables_cleanup.json', neo4j_session, common_job_parameters)
+
+
+@timeit
+def sync_route_tables(
+    neo4j_session, boto3_session, regions, current_aws_account_id, aws_update_tag,
+    common_job_parameters,
+):
+    for region in regions:
+        logger.debug("Syncing EC2 route_tables for region '%s' in account '%s'.", region, current_aws_account_id)
+        data = get_route_table_data(boto3_session, region)
+        load_route_tables(neo4j_session, data, region, current_aws_account_id, aws_update_tag)
+    cleanup_route_tables(neo4j_session, common_job_parameters)

--- a/cartography/intel/aws/ec2/route_table.py
+++ b/cartography/intel/aws/ec2/route_table.py
@@ -20,7 +20,7 @@ def get_route_table_data(boto3_session, region):
 
 
 def _get_implicit_subnet_association_statement():
-    INGEST_IMPLICIT_SUBNET_ASSOCIATIONS_TEMPLATE ="""
+    INGEST_IMPLICIT_SUBNET_ASSOCIATIONS_TEMPLATE = """
     UNWIND {RouteTables} as route_table
     UNWIND route_table.Associations as association
         MATCH (rtable:RouteTable{id: route_table.RouteTableId})
@@ -36,7 +36,7 @@ def _get_implicit_subnet_association_statement():
 
 
 def _get_explicit_subnet_association_statement():
-    INGEST_EXPLICIT_SUBNET_ASSOCIATIONS_TEMPLATE ="""
+    INGEST_EXPLICIT_SUBNET_ASSOCIATIONS_TEMPLATE = """
     UNWIND {RouteTables} as route_table
     UNWIND route_table.Associations as association
         MATCH (rtable:RouteTable{id: route_table.RouteTableId})
@@ -68,7 +68,7 @@ def load_subnet_associations(neo4j_session, route_tables, aws_update_tag):
 
 
 def _get_routes_statement():
-    INGEST_ROUTE_TEMPLATE ="""
+    INGEST_ROUTE_TEMPLATE = """
     UNWIND {RouteTables} as route_table
     UNWIND route_table.Routes as route_data
         MERGE (new_route:Route{id: route_table.RouteTableId + '|' + 

--- a/cartography/intel/aws/ec2/route_table.py
+++ b/cartography/intel/aws/ec2/route_table.py
@@ -136,7 +136,7 @@ def _get_routes_statement():
         )
 
         WITH new_route
-        OPTIONAL MATCH (igw:EC2InternetGateway{id: new_route.gateway_id})
+        OPTIONAL MATCH (igw:InternetGateway{id: new_route.gateway_id})
         WITH igw, new_route
         FOREACH(ignoreMe IN CASE igw WHEN null THEN [] ELSE [1] END |
             MERGE (new_route)-[r:ROUTE_TARGET]->(igw)

--- a/cartography/intel/aws/resourcegroupstaggingapi.py
+++ b/cartography/intel/aws/resourcegroupstaggingapi.py
@@ -47,7 +47,7 @@ def get_bucket_name_from_arn(bucket_arn):
 TAG_RESOURCE_TYPE_MAPPINGS = {
     'ec2:dhcp-options': {'label': 'DHCPOptions', 'property': 'id', 'id_func': get_short_id_from_ec2_arn},
     'ec2:instance': {'label': 'EC2Instance', 'property': 'id', 'id_func': get_short_id_from_ec2_arn},
-    'ec2:internet-gateway': {'label': 'EC2InternetGateway', 'property': 'id', 'id_func': get_short_id_from_ec2_arn},
+    'ec2:internet-gateway': {'label': 'InternetGateway', 'property': 'id', 'id_func': get_short_id_from_ec2_arn},
     'ec2:network-acl': {'label': 'NetworkAcl', 'property': 'id', 'id_func': get_short_id_from_ec2_arn},
     'ec2:network-interface': {'label': 'NetworkInterface', 'property': 'id', 'id_func': get_short_id_from_ec2_arn},
     'ec2:route-table': {'label': 'RouteTable', 'property': 'id', 'id_func': get_short_id_from_ec2_arn},

--- a/cartography/intel/aws/resourcegroupstaggingapi.py
+++ b/cartography/intel/aws/resourcegroupstaggingapi.py
@@ -47,8 +47,10 @@ def get_bucket_name_from_arn(bucket_arn):
 TAG_RESOURCE_TYPE_MAPPINGS = {
     'ec2:dhcp-options': {'label': 'DHCPOptions', 'property': 'id', 'id_func': get_short_id_from_ec2_arn},
     'ec2:instance': {'label': 'EC2Instance', 'property': 'id', 'id_func': get_short_id_from_ec2_arn},
+    'ec2:internet-gateway': {'label': 'EC2InternetGateway', 'property': 'id', 'id_func': get_short_id_from_ec2_arn},
     'ec2:network-acl': {'label': 'NetworkAcl', 'property': 'id', 'id_func': get_short_id_from_ec2_arn},
     'ec2:network-interface': {'label': 'NetworkInterface', 'property': 'id', 'id_func': get_short_id_from_ec2_arn},
+    'ec2:route-table': {'label': 'RouteTable', 'property': 'id', 'id_func': get_short_id_from_ec2_arn},
     'ec2:security-group': {'label': 'EC2SecurityGroup', 'property': 'id', 'id_func': get_short_id_from_ec2_arn},
     'ec2:subnet': {'label': 'EC2Subnet', 'property': 'subnetid', 'id_func': get_short_id_from_ec2_arn},
     'ec2:vpc': {'label': 'AWSVpc', 'property': 'id', 'id_func': get_short_id_from_ec2_arn},


### PR DESCRIPTION
- Adds CIDR association nodes for Subnet nodes.
- Adds support for InternetGateway
  - attaches it to VPC using `ATTACHED_TO` relation. E.g `EC2InternetGateway` -[ATTACHED_TO]-> `AWSVpc`
- Adds support for RouteTable
  - Creates two nodes, `RouteTable` and `Route`
  - They have the relation `Route`-[ROUTE_OF]-> `RouteTable`
  - There can be targets of a Route and are defined by `ROUTE_TARGET`. E.g `Route` -[ROUTE_TARGET]-> `EC2InternetGateway`
  - Some targets of routes are not currently supported by cartography, hence will be added later. Currently it supports
    - Network Interface
    - Internet Gateway
    - Transit Gateway
